### PR TITLE
Ask for debug privilege, improve error messages

### DIFF
--- a/sysrun.cpp
+++ b/sysrun.cpp
@@ -65,9 +65,25 @@ BOOL SetPrivilege(HANDLE hToken, PCTSTR lpszPrivilege, bool bEnablePrivilege) {
 	return TRUE;
 }
 
+BOOL EnableDebugPrivilege(void) {
+	HANDLE hToken;
+	BOOL result;
+	if (!::OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken)) {
+		return FALSE;
+	}
+	result = SetPrivilege(hToken, SE_DEBUG_NAME, TRUE);
+	::CloseHandle(hToken);
+	return result;
+}
+
 int wmain(int argc, const wchar_t* argv[]) {
 	if (argc < 2)
 		return Usage();
+
+	if (FALSE == EnableDebugPrivilege()) {
+		printf("EnableDebugPrivilege failed: Access denied (are you running elevated?)\n");
+		return 1;
+	}
 
 	auto hToken = OpenSystemProcessToken();
 	if (!hToken) {

--- a/sysrun.cpp
+++ b/sysrun.cpp
@@ -71,7 +71,7 @@ int wmain(int argc, const wchar_t* argv[]) {
 
 	auto hToken = OpenSystemProcessToken();
 	if (!hToken) {
-		printf("Access denied (are you running elevated?)\n");
+		printf("OpenSystemProcessToken failed: Access denied (are you running elevated?)\n");
 		return 1;
 	}
 
@@ -100,7 +100,7 @@ int wmain(int argc, const wchar_t* argv[]) {
 	BOOL impersonated = ::SetThreadToken(nullptr, hDupToken);
 	assert(impersonated);
 	if (!impersonated) {
-		printf("Access denied (are you running elevated?)\n");
+		printf("SetThreadToken failed: Access denied (are you running elevated?)\n");
 		return 1;
 	}
 
@@ -112,7 +112,7 @@ int wmain(int argc, const wchar_t* argv[]) {
 
 	if (!SetPrivilege(hDupToken, SE_ASSIGNPRIMARYTOKEN_NAME, TRUE) ||
 		!SetPrivilege(hDupToken, SE_INCREASE_QUOTA_NAME, TRUE)) {
-		printf("Insufficient priveleges\n");
+		printf("SetPrivilege failed: Insufficient privileges\n");
 		return 1;
 	}
 


### PR DESCRIPTION
Hi,
Iv'e tested `sysrun.exe` from an elevated command prompt, and it doesn't seems to be working.
However, running it inside Visual Studio under a debugger seems to work as expected, since the debugger is already asking for `SeDebugPrivilege`, which is needed by `OpenProcess()` in order to open another process running under `SYSTEM` context.


Iv'e added a code that asks for `SeDebugPrivilege` on sysrun start.

Thanks for this nice tool.